### PR TITLE
Use numTasks as List initial capacity

### DIFF
--- a/dotnet/Program.cs
+++ b/dotnet/Program.cs
@@ -1,6 +1,6 @@
 int numTasks = int.Parse(args[0]);
 
-List<Task> tasks = new List<Task>();
+List<Task> tasks = new List<Task>(numTasks);
 
 for (int i = 0; i < numTasks; i++)
 {


### PR DESCRIPTION
Initializing the `List<Task>` with the initial capacity as `numTasks` should avoid the automatic resizing that the list does behind the scenes when calling `.Add()` if it would exceed the internal array size.

Might be noticeable in the 100k/1M tasks benchmark.