### PR TITLE
fix(go): do not use defer in goroutine

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -1,32 +1,30 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "strconv"
-    "sync"
-    "time"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
 )
 
 func main() {
-    numRoutines := 100000
-    if len(os.Args) > 1 {
-        n, err := strconv.Atoi(os.Args[1])
-        if err == nil {
-            numRoutines = n
-        }
-    }
+	numRoutines := 100000
+	if len(os.Args) > 1 {
+		n, err := strconv.Atoi(os.Args[1])
+		if err == nil {
+			numRoutines = n
+		}
+	}
 
-    var wg sync.WaitGroup
-    for i := 0; i < numRoutines; i++ {
-	wg.Add(1)
-	go func() {
-	    defer wg.Done()
-	    time.Sleep(10 * time.Second)
-	}()
-    }
-    wg.Wait()
-    fmt.Println("All goroutines finished.")
+	var wg sync.WaitGroup
+	for i := 0; i < numRoutines; i++ {
+		wg.Add(1)
+		go func() {
+			time.Sleep(10 * time.Second)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	fmt.Println("All goroutines finished.")
 }
-
-


### PR DESCRIPTION
This requires extra allocation that is not needed if we swap order.
Functionally it is exactly the same code.

Additionally it reformats code to match Go standards.
